### PR TITLE
chore(deps): replace strings as per the updates

### DIFF
--- a/.lighthouse/jenkins-x/golint.yaml
+++ b/.lighthouse/jenkins-x/golint.yaml
@@ -14,7 +14,7 @@ spec:
             - image: uses:jenkins-x/jx3-pipeline-catalog/tasks/git-clone/git-clone-pr.yaml@versionStream
               name: ""
               resources: {}
-            - image: uses:spring-financial-group/DevOps/pipelines/golang-lint.yaml@main
+            - image: uses:spring-financial-group/mqube-pipeline-catalog/tasks/go/golang-lint.yaml@main
               name: ""
               resources: {}
   podTemplate: {}

--- a/.lighthouse/jenkins-x/release.yaml
+++ b/.lighthouse/jenkins-x/release.yaml
@@ -42,7 +42,7 @@ spec:
           script: |
             #!/usr/bin/env sh
             sed -i 's/jx3mqubebuild/mqubeoss/g' .jx/variables.sh
-        - image: uses:spring-financial-group/DevOps/pipelines/golang-lint.yaml@main
+        - image: uses:spring-financial-group/mqube-pipeline-catalog/tasks/go/golang-lint.yaml@main
           name: ""
           resources: {}
         - image: golang:1.18


### PR DESCRIPTION
This pull request replaces the following string pairs:

- File: /home/gav/projects/stringchange-repos/docker-credential-acr-env/.lighthouse/jenkins-x/golint.yaml
  - `uses:spring-financial-group/DevOps/pipelines/golang-lint.yaml` → `uses:spring-financial-group/mqube-pipeline-catalog/tasks/go/golang-lint.yaml`
- File: /home/gav/projects/stringchange-repos/docker-credential-acr-env/.lighthouse/jenkins-x/release.yaml
  - `uses:spring-financial-group/DevOps/pipelines/golang-lint.yaml` → `uses:spring-financial-group/mqube-pipeline-catalog/tasks/go/golang-lint.yaml`
